### PR TITLE
Code Clean UP

### DIFF
--- a/parson.h
+++ b/parson.h
@@ -27,66 +27,67 @@ extern "C"
 {
 #endif
 
-/* Data structures, enums and typedefs */
-struct json_object_t;
-typedef struct json_object_t JSON_Object;
-struct json_array_t;
-typedef struct json_array_t JSON_Array;
-struct json_value_t;
-typedef struct json_value_t JSON_Value;
 
-enum json_value_type {
-    JSONError = 0,
-    JSONNull = 1,
-    JSONString = 2,
-    JSONNumber = 3,
-    JSONObject = 4,
-    JSONArray = 5,
+#include <stddef.h>   /* size_t */
+
+
+/* Data structures, enums and typedefs */
+typedef struct json_object_t JSON_Object;
+typedef struct json_array_t  JSON_Array;
+typedef struct json_value_t  JSON_Value;
+
+typedef enum JSON_value_t {
+    JSONError   = 0,
+    JSONNull    = 1,
+    JSONString  = 2,
+    JSONNumber  = 3,
+    JSONObject  = 4,
+    JSONArray   = 5,
     JSONBoolean = 6
-};
+} JSON_value_t;
 
 /* Parses first JSON value in a file, returns NULL in case of error */
-JSON_Value * json_parse_file(const char *filename);
+JSON_Value *  json_parse_file(const char *filename);
 
 /*  Parses first JSON value in a string, returns NULL in case of error */
-JSON_Value * json_parse_string(const char *string);
+JSON_Value *  json_parse_string(const char *string);
 
 /* JSON Object */
-JSON_Value * json_object_get_value(const JSON_Object *object, const char *name);
-const char * json_object_get_string(const JSON_Object *object, const char *name);
-double json_object_get_number(const JSON_Object *object, const char *name);
-JSON_Object * json_object_get_object(const JSON_Object *object, const char *name);
-JSON_Array * json_object_get_array(const JSON_Object *object, const char *name);
-int json_object_get_boolean(const JSON_Object *object, const char *name);
+JSON_Value *  json_object_get_value  (const JSON_Object *object, const char *name);
+const char *  json_object_get_string (const JSON_Object *object, const char *name);
+double        json_object_get_number (const JSON_Object *object, const char *name);
+JSON_Object*  json_object_get_object (const JSON_Object *object, const char *name);
+JSON_Array *  json_object_get_array  (const JSON_Object *object, const char *name);
+int           json_object_get_boolean(const JSON_Object *object, const char *name);
 
 /* dotget functions enable addressing values with dot notation in nested objects,
   just like in structs or c++/java/c# objects (e.g. objectA.objectB.value). 
   Because valid names in JSON can contain dots, some values may be inaccessible
   this way. */    
-JSON_Value * json_object_dotget_value(const JSON_Object *object, const char *name);
-const char * json_object_dotget_string(const JSON_Object *object, const char *name);
-double json_object_dotget_number(const JSON_Object *object, const char *name);
-JSON_Object * json_object_dotget_object(const JSON_Object *object, const char *name);
-JSON_Array * json_object_dotget_array(const JSON_Object *object, const char *name);
-int json_object_dotget_boolean(const JSON_Object *object, const char *name);
+JSON_Value *  json_object_dotget_value  (const JSON_Object *object, const char *name);
+const char *  json_object_dotget_string (const JSON_Object *object, const char *name);
+double        json_object_dotget_number (const JSON_Object *object, const char *name);
+JSON_Object*  json_object_dotget_object (const JSON_Object *object, const char *name);
+JSON_Array *  json_object_dotget_array  (const JSON_Object *object, const char *name);
+int           json_object_dotget_boolean(const JSON_Object *object, const char *name);
     
 /* JSON Array */
-JSON_Value * json_array_get_value(const JSON_Array *array, size_t index);
-const char * json_array_get_string(const JSON_Array *array, size_t index);
-double json_array_get_number(const JSON_Array *array, size_t index);
-JSON_Object * json_array_get_object(const JSON_Array *array, size_t index);
-JSON_Array * json_array_get_array(const JSON_Array *array, size_t index);
-int json_array_get_boolean(const JSON_Array *array, size_t index);
-size_t json_array_get_count(const JSON_Array *array);
+JSON_Value *  json_array_get_value  (const JSON_Array *array, size_t index);
+const char *  json_array_get_string (const JSON_Array *array, size_t index);
+double        json_array_get_number (const JSON_Array *array, size_t index);
+JSON_Object*  json_array_get_object (const JSON_Array *array, size_t index);
+JSON_Array *  json_array_get_array  (const JSON_Array *array, size_t index);
+int           json_array_get_boolean(const JSON_Array *array, size_t index);
+size_t        json_array_get_count  (const JSON_Array *array);
 
 /* JSON Value */
-enum json_value_type json_value_get_type(const JSON_Value *value);
-JSON_Object * json_value_get_object(const JSON_Value *value);
-JSON_Array * json_value_get_array(const JSON_Value *value);
-const char * json_value_get_string(const JSON_Value *value);
-double json_value_get_number(const JSON_Value *value);
-int json_value_get_boolean(const JSON_Value *value);
-void json_value_free(JSON_Value *value);
+JSON_value_t  json_value_get_type   (const JSON_Value *value);
+JSON_Object*  json_value_get_object (const JSON_Value *value);
+JSON_Array *  json_value_get_array  (const JSON_Value *value);
+const char *  json_value_get_string (const JSON_Value *value);
+double        json_value_get_number (const JSON_Value *value);
+int           json_value_get_boolean(const JSON_Value *value);
+void          json_value_free       (JSON_Value *value);
 
 #ifdef __cplusplus
 }

--- a/tests.c
+++ b/tests.c
@@ -19,10 +19,12 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
 */
+
+#include "parson.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "parson.h"
 
 #define TEST(A) printf("%-72s-",#A);              \
                 if(A){puts(" OK");tests_passed++;} \


### PR DESCRIPTION
Hi kgabis,
I'm new at this Pull Request 
- replace TAB with SpaceTAB
- kill space at EOL
- rename enum in parson.h to 'typedef enum JSON_value_t'
- remove the need to write 'enum' in fuctions
- move '#include "parson.h" to the first line so that .h compile by itself
- add '#include stddef.h' in parson.h to get 'size_t' symbol
- remove '#include stddef.h' in parson.c
- remove struct json_object_t; struct json_array_t;struct json_value_t; in parson.h
- code formatting

After that all test pass OK

Thanks,

Sylvain.
