### PR TITLE
Fix macro argument bug

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -36,7 +36,7 @@
 #define MAX_NESTING               19
 #define sizeof_token(a)       (sizeof(a) - 1)
 #define skip_char(str)        ((*str)++)
-#define skip_whitespaces(str) while (isspace(**string)) { skip_char(string); }
+#define skip_whitespaces(str) while (isspace(**str)) { skip_char(str); }
 #define MAX(a, b)             ((a) > (b) ? (a) : (b))
 
 #define parson_malloc(a)     malloc(a)


### PR DESCRIPTION
Macro argument was called `str` while `string` was used in the body. This actually didn't result in a bug since all instances of the macro were called with a variable as argument named string. But it is better to fix this for future bugs that this may result in.
