### PR TITLE
Warning when compiling with -O2

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -500,7 +500,7 @@ JSON_Value * json_parse_file(const char *filename) {
     rewind(fp);
     file_contents = (char*)parson_malloc(sizeof(char) * (file_size + 1));
     if (!file_contents) { fclose(fp); return NULL; }
-    fread(file_contents, file_size, 1, fp);
+    if (fread(file_contents, file_size, 1, fp) < 1) { fclose(fp); return NULL; }
     fclose(fp);
     file_contents[file_size] = '\0';
     output_value = json_parse_string(file_contents);


### PR DESCRIPTION
Checking that fread _actually_ succeeds, fix the warning bellow when compiling with -O1, -O2 or -O3.

```
"warning: ignoring return value of 'fread', declared with attribute warn_unused_result"
```
