### PR TITLE
Check ferror if fread call fails in json_parse_file

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -500,7 +500,9 @@ JSON_Value * json_parse_file(const char *filename) {
     rewind(fp);
     file_contents = (char*)parson_malloc(sizeof(char) * (file_size + 1));
     if (!file_contents) { fclose(fp); return NULL; }
-    if (fread(file_contents, file_size, 1, fp) < 1) { fclose(fp); return NULL; }
+    if (fread(file_contents, file_size, 1, fp) < 1) {
+        if (ferror(fp)) { fclose(fp); return NULL; }
+    }
     fclose(fp);
     file_contents[file_size] = '\0';
     output_value = json_parse_string(file_contents);


### PR DESCRIPTION
I noticed on my system that parse_json_file was failing on a perfectly good json file. After some digging I noticed the fread call was returning 0 which is handled as an error in your HEAD revision. However the fread man page states:

fread() does not distinguish between end-of-file and error, and callers must use feof(3) and ferror(3) to determine which occurred.

It's unclear to me how this code would have ever worked since you're always trying to read in the entire file and so EOF would always be reached and NULL always returned. Am I missing something?
