### PR TITLE
add fix and test for url slash fix

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -437,7 +437,12 @@ static const char * get_processed_string(const char **string) {
         if (*unprocessed_ptr == '\\') {
             unprocessed_ptr++;
             switch (*unprocessed_ptr) {
-                case '\"': case '\\': case '/': break;
+                case '\"': case '\\': case '/':
+                  if ('/' == *(unprocessed_ptr)) {
+                    *processed_ptr = '/';
+                    *(processed_ptr+1) = '/';
+                  }
+                  break;
                 case 'b': *processed_ptr = '\b'; break;
                 case 'f': *processed_ptr = '\f'; break;
                 case 'n': *processed_ptr = '\n'; break;

--- a/tests.c
+++ b/tests.c
@@ -38,6 +38,7 @@ void test_suite_2(JSON_Value *value);
 void test_suite_2_no_comments(void);
 void test_suite_2_with_comments(void);
 void test_suite_3(void);
+void test_with_encoded_url(void);
 
 char *read_file(const char *filename);
 void print_commits_info(const char *username, const char *repo);
@@ -52,6 +53,7 @@ int main() {
     test_suite_2_no_comments();
     test_suite_2_with_comments();
     test_suite_3();
+    test_with_encoded_url();
     printf("Tests failed: %d\n", tests_failed);
     printf("Tests passed: %d\n", tests_passed);
     return 0;
@@ -201,6 +203,14 @@ void test_suite_3(void) {
     TEST(json_parse_string("[-007]") == NULL);
     TEST(json_parse_string("[-07.0]") == NULL);
     TEST(json_parse_string("[\"\\uDF67\\uD834\"]") == NULL); /* wrong order surrogate pair */
+}
+
+void test_with_encoded_url(void) {
+  JSON_Object *root;
+  JSON_Value *val;
+  TEST((val = json_parse_file("tests/test_url_encoded.txt")) != NULL);
+  root = json_value_get_object(val);
+  TEST(STREQ(json_object_get_string(root, "url"), "https://www.example.com/search?q=12345"));
 }
 
 void print_commits_info(const char *username, const char *repo) {

--- a/tests/test_url_encoded.txt
+++ b/tests/test_url_encoded.txt
@@ -1,0 +1,3 @@
+{
+  "url": "https:\/\/www.example.com\/search?q=12345"
+}


### PR DESCRIPTION
This patch fixes JSON objects who escape url's:

urls like:

```
url":["https:\/\/www.facebook.com\/photo.php?fbid=5084
```

end up getting a messed up value when decoded:

```
url":["https:/www.facebook.comphoto.php?fbid=5084
```
