### PR TITLE
Adding the ability to count lines parsed to pin-point syntax errors

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -38,9 +38,11 @@
 #define MAX_NESTING               19
 #define DOUBLE_SERIALIZATION_FORMAT "%f"
 
+unsigned int JSON_Lines_Parsed = 0;
+
 #define SIZEOF_TOKEN(a)       (sizeof(a) - 1)
 #define SKIP_CHAR(str)        ((*str)++)
-#define SKIP_WHITESPACES(str) while (isspace(**str)) { SKIP_CHAR(str); }
+#define SKIP_WHITESPACES(str) while (isspace(**str)) { if ((**str) == '\n') JSON_Lines_Parsed++; SKIP_CHAR(str); }
 #define MAX(a, b)             ((a) > (b) ? (a) : (b))
 
 #undef malloc
@@ -272,13 +274,13 @@ static void remove_comments(char *string, const char *start_token, const char *e
             in_string = !in_string;
         } else if (!in_string && strncmp(string, start_token, start_token_len) == 0) {
 			for(i = 0; i < start_token_len; i++)
-                string[i] = ' ';
+                string[i] = (string[i] == '\n' ? '\n': ' ');
         	string = string + start_token_len;
             ptr = strstr(string, end_token);
             if (!ptr)
                 return;
             for (i = 0; i < (ptr - string) + end_token_len; i++)
-                string[i] = ' ';
+                string[i] = (string[i] == '\n' ? '\n': ' ');
           	string = ptr + end_token_len - 1;
         }
         escaped = 0;

--- a/parson.h
+++ b/parson.h
@@ -31,6 +31,8 @@ extern "C"
     
 #include <stddef.h>   /* size_t */    
     
+extern unsigned int JSON_Lines_Parsed;
+
 /* Types and enums */
 typedef struct json_object_t JSON_Object;
 typedef struct json_array_t  JSON_Array;


### PR DESCRIPTION
This will allow a user to locate parse errors. If parser
returns an error, then JSON_Lines_Parsed will have the
number successfully parsed lines. Example sage below:

      JSON_Value_Type jtype = json_value_get_type(root_value);
      if (jtype == -1)
          printf("Parse error on or near line %i \n", JSON_Lines_Parsed);