### PR TITLE
Fix for array element validation

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -1646,7 +1646,7 @@ JSON_Status json_validate(const JSON_Value *schema, const JSON_Value *value) {
             temp_schema_value = json_array_get_value(schema_array, 0);
             for (i = 0; i < json_array_get_count(value_array); i++) {
                 temp_value = json_array_get_value(value_array, i);
-                if (json_validate(temp_schema_value, temp_value) == 0) {
+                if (json_validate(temp_schema_value, temp_value) == JSONFailure) {
                     return JSONFailure;
                 }
             }

--- a/tests.c
+++ b/tests.c
@@ -382,9 +382,13 @@ void test_suite_7(void) {
     JSON_Value *val_from_file = json_parse_file("tests/test_5.txt");
     JSON_Value *schema = json_value_init_object();
     JSON_Object *schema_obj = json_value_get_object(schema);
+    JSON_Array *interests_arr = NULL;
     json_object_set_string(schema_obj, "first", "");
     json_object_set_string(schema_obj, "last", "");
     json_object_set_number(schema_obj, "age", 0);
+    json_object_set_value(schema_obj, "interests", json_value_init_array());
+    interests_arr = json_object_get_array(schema_obj, "interests");
+    json_array_append_string(interests_arr, "");
     json_object_set_null(schema_obj, "favorites");
     TEST(json_validate(schema, val_from_file) == JSONSuccess);
     json_object_set_string(schema_obj, "age", "");


### PR DESCRIPTION
Change adds a test for validating elements of an array based on a schema, which exposes an issue in the library code.  And change includes a fix for this issue, which is just a typo comparing a validation result to '0' instead of  'JSONFailure' when checking for failure.