### PR TITLE
Add query support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,50 @@ Date       SHA        Author
 ...
 ```
 
+###Query
+When you simply read JSON and get values without modifying it, you can use '.' and '[]' to traverse object and array hierarchy.
+```c
+void query_example(void) {
+    JSON_Value *root_value;
+    char *json_string;
+    
+    /* json string to parse */
+    json_string = "{"
+            "\"list\":["
+                "{"
+                    "\"index\":0,"
+                    "\"data\":{"
+                        "\"prop\":\"value\""
+                    "}"
+                "},"
+                "{"
+                    "\"index\":1,"
+                    "\"data\":{"
+                        "\"prop\":null"
+                    "}"
+                "},"
+                "{"
+                    "\"index\":2,"
+                    "\"data\":{"
+                        "\"prop\":123"
+                    "}"
+                "}"
+            "]"
+        "}";
+    
+    /* parsing json string */
+    root_value = json_parse_string(json_string);
+    
+    if (JSONObject == json_type(root_value)) {
+        printf("Query: \"%s\", Result: \"%s\"\n", ".list[0].data.prop", json_value_query_string(root_value, ".list[0].data.prop"));
+        printf("Query: \"%s\", Result: \"%d\"\n", ".list[2].data.prop", (int)json_value_query_number(root_value, ".list[2].data.prop"));
+    }
+    
+    /* cleanup code */
+    json_value_free(root_value);
+}
+```
+
 ###Persistence
 In this example I'm using parson to save user information to a file and then load it and validate later.
 ```c

--- a/parson.c
+++ b/parson.c
@@ -142,8 +142,8 @@ static char * parson_strdup(const char *string) {
     return parson_strndup(string, strlen(string));
 }
 
-static int is_utf16_hex(const unsigned char *s) {
-    return isxdigit(s[0]) && isxdigit(s[1]) && isxdigit(s[2]) && isxdigit(s[3]);
+static int is_utf16_hex(const unsigned char *string) {
+    return isxdigit(string[0]) && isxdigit(string[1]) && isxdigit(string[2]) && isxdigit(string[3]);
 }
 
 static int num_bytes_in_utf8_sequence(unsigned char c) {

--- a/parson.h
+++ b/parson.h
@@ -224,6 +224,15 @@ const char  *   json_string (const JSON_Value *value);
 double          json_number (const JSON_Value *value);
 int             json_boolean(const JSON_Value *value);
 
+/* Query */
+JSON_Value  * json_value_query_value  (JSON_Value *value, const char *query);
+const char  * json_value_query_string (JSON_Value *value, const char *query);
+JSON_Object * json_value_query_object (JSON_Value *value, const char *query);
+JSON_Array  * json_value_query_array  (JSON_Value *value, const char *query);
+double        json_value_query_number (JSON_Value *value, const char *query); /* returns 0 on fail */
+int           json_value_query_boolean(JSON_Value *value, const char *query); /* returns -1 on fail */
+JSON_Value  * json_query              (JSON_Value *value, const char *query); /* shorter version of json_value_query_value */
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests.c
+++ b/tests.c
@@ -208,6 +208,36 @@ void test_suite_2(JSON_Value *root_value) {
     TEST(json_object_get_object(root_object, "empty object") != NULL);
     TEST(json_object_get_array(root_object, "empty array") != NULL);
 
+    TEST((json_value_query_value(root_value, ".") == root_value));
+    TEST((json_value_query_value(root_value, "..") == root_value));
+    TEST((json_value_query_value(root_value, "...") == root_value));
+    TEST((json_value_query_value(root_value, "[]") == root_value));
+    TEST((json_value_query_value(root_value, NULL) == NULL));
+    TEST((json_value_query_value(root_value, "") == NULL));
+    TEST((json_value_query_value(root_value, "noexist") == NULL));
+    TEST((json_value_query_value(root_value, ".noexist") == NULL));
+    TEST((json_value_query_value(root_value, "..noexist") == NULL));
+    TEST((json_value_query_value(root_value, "noexist.prop") == NULL));
+    TEST((json_value_query_value(root_value, ".noexist.prop") == NULL));
+    TEST((json_value_query_value(root_value, "..noexist.prop") == NULL));
+    TEST((json_value_query_value(root_value, ".[.no[[exist].prop") == NULL));
+    TEST((json_value_query_value(root_value, ".object].nested true") == NULL));
+    TEST(STREQ(json_value_query_string(root_value, "[0]"), "lorem ipsum"));
+    TEST(STREQ(json_value_query_string(root_value, "object.nested object.lorem"), "ipsum"));
+    TEST(STREQ(json_value_query_string(root_value, "object.nested object[0]"), "ipsum"));
+    TEST(STREQ(json_value_query_string(root_value, "object.nested array[0]"), "lorem"));
+    TEST(STREQ(json_value_query_string(root_value, ".object[nested array][1]"), "ipsum"));
+    TEST((json_value_query_number(root_value, ".object[nested number]") == 123));
+    TEST((json_value_query_boolean(root_value, ".object[nested true]") == 1));
+
+    array = json_value_query_array(root_value, ".object[nested array][]");
+    TEST(array != NULL);
+    TEST(json_array_get_count(array) == 2);
+
+    array = json_value_query_array(root_value, ".[x^2 array][]");
+    TEST(array != NULL);
+    TEST(json_array_get_count(array) == 11);
+
 }
 
 void test_suite_2_no_comments(void) {


### PR DESCRIPTION
Parson already has dotget and dotset functions which I admit are minimal and sufficient as API.
Even so, many of JSON will contain both objects and arrays, in a way it'll be easier to have the accessing syntax to traverse JSON handling both objects and arrays together just like JavaScript.

```c
value = json_value_query_string(root_value, ".list[0].data.prop");
value = json_value_query_string(root_value, ".list[0][data].prop");
```