### PR TITLE
apply CMake instead of GNU Make

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required (VERSION 2.8)
+
+project (libparson)
+
+include (version.cmake.in)
+
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -std=c89 -pedantic-errors")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+
+include_directories (${PROJECT_SOURCE_DIR})
+
+add_library (parson SHARED parson.c)
+
+set_target_properties (parson PROPERTIES
+	SOVERSION ${so_version}
+	VERSION ${PARSON_VERSION}
+)
+
+install (FILES parson.h DESTINATION include/parson)
+install (TARGETS parson DESTINATION lib)
+
+add_custom_target (uninstall
+	COMMAND ${CMAKE_COMMAND} -E remove
+		`cat ${PROJECT_BINARY_DIR}/install_manifest.txt`
+)
+
+if (${CMAKE_BUILD_TYPE} MATCHES Debug)
+	include (test.cmake.in)
+endif ()

--- a/makefile
+++ b/makefile
@@ -1,0 +1,1 @@
+$(error DEPRECATED: Use CMake instead of GNU Make)

--- a/test.cmake.in
+++ b/test.cmake.in
@@ -1,0 +1,52 @@
+enable_testing ()
+
+add_executable (test-c-standalone EXCLUDE_FROM_ALL tests.c parson.c)
+
+add_executable (test-c-linked EXCLUDE_FROM_ALL tests.c)
+target_link_libraries (test-c-linked parson)
+
+add_custom_command (
+	OUTPUT tests.cxx
+	COMMAND ${CMAKE_COMMAND} -E create_symlink
+		${PROJECT_SOURCE_DIR}/tests
+		${PROJECT_BINARY_DIR}/tests
+	COMMAND ${CMAKE_COMMAND} -E create_symlink
+		${PROJECT_SOURCE_DIR}/tests.c
+		${PROJECT_BINARY_DIR}/tests.cxx
+)
+
+add_executable (test-cxx-standalone EXCLUDE_FROM_ALL tests.cxx parson.c)
+
+add_executable (test-cxx-linked EXCLUDE_FROM_ALL tests.cxx)
+target_link_libraries (test-cxx-linked parson)
+
+add_test (test-c-standalone-build
+	${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}
+		--target test-c-standalone
+)
+
+add_test (test-cxx-standalone-build
+	${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}
+		--target test-cxx-standalone
+)
+
+add_test (test-c-linked-build
+	${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}
+		--target test-c-linked
+)
+
+add_test (test-cxx-linked-build
+	${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}
+		--target test-cxx-linked
+)
+
+add_test (test-c-standalone-run test-c-standalone)
+add_test (test-cxx-standalone-run test-cxx-standalone)
+add_test (test-c-linked-run test-c-linked)
+add_test (test-cxx-linked-run test-cxx-linked)
+
+add_custom_command (TARGET parson
+	POST_BUILD
+	COMMAND ${CMAKE_COMMAND} --build ${PROJECT_BINARY_DIR}
+		--target test
+)

--- a/version.cmake.in
+++ b/version.cmake.in
@@ -1,0 +1,28 @@
+# from pacakge.json
+set (PARSON_VERSION 0.0.0 CACHE STRING "set library version")
+
+if (PARSON_VERSION STREQUAL 0.0.0)
+	execute_process (
+		COMMAND git rev-parse --short HEAD
+		WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+		OUTPUT_VARIABLE git_rev
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+		ERROR_VARIABLE git_err
+	)
+
+	if (git_err)
+		message (FATAL_ERROR
+			"${git_err}"
+			"*** Please define PARSON_VERSION ***\n"
+		)
+	endif ()
+
+	set (PARSON_VERSION ${PARSON_VERSION}.${git_rev})
+endif ()
+
+string (REPLACE "." ";" version_list ${PARSON_VERSION})
+
+list (GET version_list 0 so_version)
+
+message (STATUS "set SOVERSION to ${so_version}")
+message (STATUS "set VERSION to ${PARSON_VERSION}")


### PR DESCRIPTION
## Overview
* use CMake and creates shared library
* tested on Ubuntu 16.10 w/ CMake 3.5.2 and Ubuntu 14.04 w/ CMake 2.8.12
## Debug Build
```bash
$ mkdir cmake.build
$ cd cmake.build
$ cmake ../ -DCMAKE_BUILD_TYPE=Debug
$ make
```
* creates shared library named libparson.so(.0.0.0.($git_rev))
* so version is automatically generated from git revision or can be defined via -DPARSON_VERSION
* compiles tests.c and runs it
## Release Build
```bash
$ mkdir cmake.build
$ cd cmake.build
$ cmake ../ -DCMAKE_BUILD_TYPE=Release
$ make
```
* all stuffs are equal to Debug Build, but doesn't compile tests.c
## Install
```bash
$ cd cmake.build
$ sudo make install
```
* installs parson.h to /usr/local/include/parson/
* installs libparson.so.* /usr/local/lib/