### PR TITLE
Return a JSONError value with an error string if parsing fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ CFLAGS = -O0 -g -Wall -Wextra -std=c89 -pedantic-errors
 CPPC = g++
 CPPFLAGS = -O0 -g -Wall -Wextra
 
+#CFLAGS += -DPARSON_RETURN_ERROR_VALUES
+#CPPFLAGS += -DPARSON_RETURN_ERROR_VALUES
+
 all: test testcpp
 
 .PHONY: test testcpp

--- a/parson.c
+++ b/parson.c
@@ -314,7 +314,7 @@ static void remove_comments(char *string, const char *start_token, const char *e
             in_string = !in_string;
         } else if (!in_string && strncmp(string, start_token, start_token_len) == 0) {
             for(i = 0; i < start_token_len; i++) {
-                string[i] = ' ';
+                string[i] = (string[i] == '\n') ? '\n' : ' ';
             }
             string = string + start_token_len;
             ptr = strstr(string, end_token);
@@ -322,7 +322,7 @@ static void remove_comments(char *string, const char *start_token, const char *e
                 return;
             }
             for (i = 0; i < (ptr - string) + end_token_len; i++) {
-                string[i] = ' ';
+                string[i] = (string[i] == '\n') ? '\n' : ' ';
             }
             string = ptr + end_token_len - 1;
         }
@@ -1158,7 +1158,6 @@ JSON_Value * json_parse_string_with_comments(const char *string) {
     string_mutable_copy_ptr = string_mutable_copy;
     result = parse_value((const char**)&string_mutable_copy_ptr, 0);
     if (!result) {
-        /* Note that line numbers may be off from multi-line comments */
         result = parse_error(string_mutable_copy, string_mutable_copy_ptr);
     }
     parson_free(string_mutable_copy);

--- a/parson.c
+++ b/parson.c
@@ -129,7 +129,7 @@ static JSON_Value * parse_boolean_value(const char **string);
 static JSON_Value * parse_number_value(const char **string);
 static JSON_Value * parse_null_value(const char **string);
 static JSON_Value * parse_value(const char **string, size_t nesting);
-static JSON_Value * parse_error(const char* start, const char* end);
+static JSON_Value * parse_error(const char *start, const char *end);
 
 /* Serialization */
 static int    json_serialize_to_buffer_r(const JSON_Value *value, char *buf, int level, int is_pretty, char *num_buf);
@@ -1052,7 +1052,7 @@ JSON_Value * json_parse_file_with_comments(const char *filename) {
 
 #if defined(PARSON_RETURN_ERROR_VALUES)
 
-static size_t get_line_number(const char* start, const char* end, size_t max) {
+static size_t get_line_number(const char *start, const char *end, size_t max) {
     size_t count = 1;
     if (start == NULL || end == NULL) {
         return 1;
@@ -1072,7 +1072,7 @@ static size_t get_line_number(const char* start, const char* end, size_t max) {
     return count;
 }
 
-static size_t get_line_byte_count(const char* start, size_t max) {
+static size_t get_line_byte_count(const char *start, size_t max) {
     size_t i = 0;
     if (start == NULL) {
         return 0;
@@ -1083,14 +1083,14 @@ static size_t get_line_byte_count(const char* start, size_t max) {
     return i;
 }
 
-static JSON_Value * parse_error(const char* start, const char* end) {
+static JSON_Value * parse_error(const char *start, const char *end) {
     /* If the type of the display number is changed
        the error format string and value of n need changed too. */
     unsigned long display_number, max_display_number = (unsigned long)-1;
     size_t n, max_line_length, line_length, line_number;
     char *error_string;
     JSON_Value *value = NULL;
-    const char* error_format = "Error on line %lu: %.*s";
+    const char *error_format = "Error on line %lu: %.*s";
 
     value = (JSON_Value*)parson_malloc(sizeof(JSON_Value));
     if (value == NULL) {
@@ -1102,8 +1102,8 @@ static JSON_Value * parse_error(const char* start, const char* end) {
     /* Subtract the specifier characters from the format and
        add enough space to hold a 64 bit unsigned integer. */
     n = strlen(error_format) - 7 + 20 + max_line_length + 1;
-    error_string = (char*)parson_malloc(n);
-    if (!error_string) {
+    error_string = (char*)parson_malloc(sizeof(char) * n);
+    if (error_string == NULL) {
         parson_free(value);
         return NULL;
     }
@@ -1122,7 +1122,7 @@ static JSON_Value * parse_error(const char* start, const char* end) {
     return value;
 }
 #else
-static JSON_Value * parse_error(const char* start, const char* end) {
+static JSON_Value * parse_error(const char *start, const char *end) {
     /* Ignore the unused arguments */
     (void)start;
     (void)end;

--- a/parson.h
+++ b/parson.h
@@ -215,6 +215,7 @@ JSON_Value_Type json_value_get_type   (const JSON_Value *value);
 JSON_Object *   json_value_get_object (const JSON_Value *value);
 JSON_Array  *   json_value_get_array  (const JSON_Value *value);
 const char  *   json_value_get_string (const JSON_Value *value);
+const char  *   json_value_get_error  (const JSON_Value *value);
 double          json_value_get_number (const JSON_Value *value);
 int             json_value_get_boolean(const JSON_Value *value);
 JSON_Value  *   json_value_get_parent (const JSON_Value *value);

--- a/tests.c
+++ b/tests.c
@@ -35,7 +35,7 @@
    on a preprocessor definition so adjust the pass criteria to match.
  */
 #if defined(PARSON_RETURN_ERROR_VALUES)
-#define PARSE_PASSED(A) ((A) != NULL && json_value_get_type(A) != JSONError)
+#define PARSE_PASSED(A) (json_value_get_type(A) != JSONError)
 #else
 #define PARSE_PASSED(A) ((A) != NULL)
 #endif
@@ -43,8 +43,8 @@
 #define TEST(A) printf("%d %-72s-", __LINE__, #A);\
                 if(A){puts(" OK");tests_passed++;}\
                 else{puts(" FAIL");tests_failed++;}
-#define TEST_PARSE_PASSES(A) { JSON_Value *v = A; TEST(PARSE_PASSED(v)) }
-#define TEST_PARSE_FAILS(A) { JSON_Value *v = A; TEST(!PARSE_PASSED(v)) }
+#define TEST_PARSE_PASSES(A) TEST(PARSE_PASSED(A))
+#define TEST_PARSE_FAILS(A) TEST(!PARSE_PASSED(A))
 #define STREQ(A, B) ((A) && (B) ? strcmp((A), (B)) == 0 : 0)
 #define EPSILON 0.000001
 


### PR DESCRIPTION
Currently, parse failures return NULL and I just have to print a generic "something went wrong" message. It would be nice to have some kind of error message pointing to the line with the problem.

This change makes the parse functions try to return a value of type JSONError with a string value containing an error message. If it cannot allocate the value then it still returns NULL. I updated the test code accordingly. Since this could break programs that expect only NULL on failure I hid it behind a preprocessor definition.

The only other API change is adding `const char* json_value_get_error(const JSON_Value *value)`.

The main limitation is that the error message contains the line number after comments are removed which may not match the line number the user sees in a file. The error message also contains part of the line that parsing failed on, so users could notice the line number and line content do not match.


I've considered a few other related changes but did not want to make overly invasive changes without finding out your preferences.
- Removing the preprocessor definition and always returning JSONError values.
- Adding a run-time setting instead of a preprocessor definition.
- Detecting whether any removed comments included a newline and suppressing the line number.
- Creating a `json_parse()` function that accepts a struct with the filename/string and feature flags (remove comments, return error values, skip line numbers, etc).
- Generating more informative messages without invasive changes to the parsing code by looking at the text around where the parse failed. Examples: 
    - If the parse failed on `]` explain that it is an unmatched array bracket.
    - If the parse failed on `},` and the previous non-whitespace character is a comma then explain that trailing commas are invalid.

It's no problem if you want to rewrite any of this or would prefer me to implement it differently. I tried to match the existing code and comment style.