### PR TITLE
Fixed condition

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -1718,7 +1718,7 @@ JSON_Status json_object_dotset_value(JSON_Object *object, const char *name, JSON
     char *current_name = NULL;
     JSON_Object *temp_obj = NULL;
     JSON_Value *new_value = NULL;
-    if (value == NULL || name == NULL || value == NULL) {
+    if (object == NULL || name == NULL || value == NULL) {
         return JSONFailure;
     }
     dot_pos = strchr(name, '.');


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A warning, found using PVS-Studio:
parson/parson.c     1721    warn    V560 A part of conditional expression is always false: value == NULL.
parson/parson.c     1721    warn    V560 A part of conditional expression is always false: value == __null.

Static analyser found `always false` issues only, but in any case the expression `value == NULL` is duplicated in one condition.