### PR TITLE
Fix signed char fed to isspace

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -45,7 +45,7 @@
 
 #define SIZEOF_TOKEN(a)       (sizeof(a) - 1)
 #define SKIP_CHAR(str)        ((*str)++)
-#define SKIP_WHITESPACES(str) while (isspace(**str)) { SKIP_CHAR(str); }
+#define SKIP_WHITESPACES(str) while (isspace((unsigned char)(**str))) { SKIP_CHAR(str); }
 #define MAX(a, b)             ((a) > (b) ? (a) : (b))
 
 #undef malloc


### PR DESCRIPTION
I'm on the Microsoft Azure IoT team, and we use this lib as part of the Azure IoT C SDK. When I compile parson.c for the ESP32, I get a [deliberately provoked warning](https://github.com/espressif/esp-idf/blob/7e3ac34704b53473c42b148a9edc578c51630064/components/newlib/include/ctype.h#L48) treated as error about a signed char being passed to isspace. This PR fixes the problem.

This is a blocking issue for me, so getting this or an equivalent fix in would be greatly appreciated.