### PR TITLE
CMake support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: cpp
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: true
+      compiler: gcc
+      addons:
+       apt:
+         packages:
+           - gcc-4.8
+           - g++-4.8
+           - cmake
+script:
+     - cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON .
+     - cmake --build .
+     - cmake --build . --target test
+     - sudo cmake --build . --target install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 2.8)
+project(parson)
+
+# Version ######################################################################
+set(PARSON_VERSION_MAJOR 0)
+set(PARSON_VERSION_MINOR 0)
+set(PARSON_VERSION_PATCH 0)
+
+# Build Options ################################################################
+option(BUILD_TESTS "Build unit tests" OFF)
+
+# Build library ################################################################
+set(SOURCE_FILES ${CMAKE_SOURCE_DIR}/parson.c ${CMAKE_SOURCE_DIR}/parson.h)
+add_library(${CMAKE_PROJECT_NAME} ${SOURCE_FILES})
+
+# Build options ################################################################
+if(WIN32 AND MSVC AND BUILD_SHARED_LIBS)
+    set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif(WIN32 AND MSVC AND BUILD_SHARED_LIBS)
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wall -Wextra -std=c89 -pedantic-errors)
+endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+
+# Install targets ##############################################################
+install(TARGETS ${CMAKE_PROJECT_NAME}
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE WORLD_READ)
+
+install(FILES parson.h DESTINATION include
+        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ GROUP_WRITE WORLD_READ)
+
+# Build and Execute Unit Test ##################################################
+if(BUILD_TESTS)
+    enable_testing()
+
+    set(TARGET_TEST test-all)
+    add_executable(${TARGET_TEST} ${CMAKE_SOURCE_DIR}/tests.c)
+    target_link_libraries(${TARGET_TEST} ${CMAKE_PROJECT_NAME})
+    add_test(NAME ${TARGET_TEST} COMMAND ${TARGET_TEST})
+endif(BUILD_TESTS)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+build: false
+
+environment:
+    matrix:
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 12
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+          CONAN_VISUAL_VERSIONS: 14
+        - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+          CONAN_VISUAL_VERSIONS: 15
+
+test_script:
+  - cmake . -DBUILD_TESTS=ON
+  - cmake --build . --config Release
+  - Release\test-all.exe


### PR DESCRIPTION
Hi!

This PR brings CMake as a new option to build Parson, including all tests.

**BONUS**
I added Travis file check build status after a new push. You can check the current state [here](https://travis-ci.org/uilianries/parson/builds/315566857)

Also, I added AppVeyor support to build on Windows. You can check the current state [here](https://ci.appveyor.com/project/uilianries/parson)

/cc @solvingj