### PR TITLE
Add CMakeLists.txt with install definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.5)
+project(parson C)
+
+add_library(parson parson.c)
+target_include_directories(parson PUBLIC $<INSTALL_INTERFACE:include>)
+
+set_target_properties(parson PROPERTIES PUBLIC_HEADER "parson.h")
+
+install(
+    TARGETS parson
+    EXPORT parsonTargets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    PUBLIC_HEADER DESTINATION include
+)
+
+install(
+    EXPORT parsonTargets
+    FILE parsonConfig.cmake
+    NAMESPACE parson::
+    DESTINATION cmake
+)
+


### PR DESCRIPTION
Hi,

would it be possible to accept the changes in this PR to add a CMakeLists.txt definition?

We would like to integrate the use parson through our own cmake config files, 
This change would enable us to consume your library using find_package.

Thanks for your attention.