### PR TITLE
add SPDX-License-Identifier

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -1,4 +1,6 @@
 /*
+ SPDX-License-Identifier: MIT
+
  Parson ( http://kgabis.github.com/parson/ )
  Copyright (c) 2012 - 2017 Krzysztof Gabis
 

--- a/parson.h
+++ b/parson.h
@@ -1,4 +1,6 @@
 /*
+ SPDX-License-Identifier: MIT
+
  Parson ( http://kgabis.github.com/parson/ )
  Copyright (c) 2012 - 2017 Krzysztof Gabis
 

--- a/tests.c
+++ b/tests.c
@@ -1,4 +1,6 @@
 /*
+ SPDX-License-Identifier: MIT
+
  Parson ( http://kgabis.github.com/parson/ )
  Copyright (c) 2012 - 2017 Krzysztof Gabis
 


### PR DESCRIPTION
SPDX-License-Identifier is useful to clarify the license (both for humans and
machines), especially when the code of the project is embedded into other
projects.

ref: https://spdx.org/using-spdx-license-identifier

Signed-off-by: Akihiro Suda <akihiro.suda.cz@hco.ntt.co.jp>