### PR TITLE
Avoid truncating strings warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(parson C)
 
 include (GNUInstallDirs)
 
-set(PARSON_VERSION 1.0.0)
+set(PARSON_VERSION 1.0.1)
 add_library(parson parson.c)
 target_include_directories(parson PUBLIC $<INSTALL_INTERFACE:include>)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parson",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repo": "kgabis/parson",
   "description": "Small json parser and reader",
   "keywords": [ "json", "parser" ],

--- a/parson.c
+++ b/parson.c
@@ -156,7 +156,7 @@ static char * parson_strndup(const char *string, size_t n) {
         return NULL;
     }
     output_string[n] = '\0';
-    strncpy(output_string, string, n);
+    memcpy(output_string, string, n);
     return output_string;
 }
 

--- a/parson.c
+++ b/parson.c
@@ -1,7 +1,7 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson 1.0.0 ( http://kgabis.github.com/parson/ )
+ Parson 1.0.1 ( http://kgabis.github.com/parson/ )
  Copyright (c) 2012 - 2019 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/parson.h
+++ b/parson.h
@@ -1,7 +1,7 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson 1.0.0 ( http://kgabis.github.com/parson/ )
+ Parson 1.0.1 ( http://kgabis.github.com/parson/ )
  Copyright (c) 2012 - 2019 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
GCC 8 introduced the `stringop-truncation` warning, which warns for
uses of `strncpy` of the form `strncpy(out, in, strlen(in))`. This
is often helpful, as this call would not copy the trailing `\0`,
potentially leading to subtle bugs.

With optimizations enabled, the function `parson_strndup` is
inlined, allowing the compiler to see that this call to `strncpy` is
of the form described above. GCC therefore outputs the warning.

In this case, the out buffer has already had the terminating `\0`
written to the end. Thus it is not necessary to copy it. GCC 9.2 is
not quite smart enough to recognize this, so it warns.

The warning is silenced by using `memcpy` instead of `strncpy`.

Although I have not benchmarked it, this change might reasonably
improve the performance of `parson_strndup`. `strncpy` checks every
byte for `\0` in addition to counting to `n`. `memcpy` does not need
to check whether the bytes it copies are `\0`.

However, if `parson_strndup` is frequently passed `char *`s with a
`\0` somewhere in the middle, then `memcpy` will copy more bytes
than necessary, hurting performance. In this case, a better solution
might be:

```
- output_string[n] = `\0`;
- strncpy(output_string, string, n);
+ strncpy(output_string, string, n+1);
```