### PR TITLE
Guard against potential integer overflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(parson C)
 
 include (GNUInstallDirs)
 
-set(PARSON_VERSION 1.0.1)
+set(PARSON_VERSION 1.0.2)
 add_library(parson parson.c)
 target_include_directories(parson PUBLIC $<INSTALL_INTERFACE:include>)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parson",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repo": "kgabis/parson",
   "description": "Small json parser and reader",
   "keywords": [ "json", "parser" ],

--- a/parson.c
+++ b/parson.c
@@ -1,7 +1,7 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson 1.0.1 ( http://kgabis.github.com/parson/ )
+ Parson 1.0.2 ( http://kgabis.github.com/parson/ )
  Copyright (c) 2012 - 2019 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/parson.c
+++ b/parson.c
@@ -1496,7 +1496,7 @@ JSON_Value * json_value_deep_copy(const JSON_Value *value) {
 size_t json_serialization_size(const JSON_Value *value) {
     char num_buf[NUM_BUF_SIZE]; /* recursively allocating buffer on stack is a bad idea, so let's do it only once */
     int res = json_serialize_to_buffer_r(value, NULL, 0, 0, num_buf);
-    return res < 0 ? 0 : (size_t)res + 1;
+    return res < 0 ? 0 : (size_t)(res) + 1;
 }
 
 JSON_Status json_serialize_to_buffer(const JSON_Value *value, char *buf, size_t buf_size_in_bytes) {

--- a/parson.c
+++ b/parson.c
@@ -1496,7 +1496,7 @@ JSON_Value * json_value_deep_copy(const JSON_Value *value) {
 size_t json_serialization_size(const JSON_Value *value) {
     char num_buf[NUM_BUF_SIZE]; /* recursively allocating buffer on stack is a bad idea, so let's do it only once */
     int res = json_serialize_to_buffer_r(value, NULL, 0, 0, num_buf);
-    return res < 0 ? 0 : (size_t)(res + 1);
+    return res < 0 ? 0 : (size_t)res + 1;
 }
 
 JSON_Status json_serialize_to_buffer(const JSON_Value *value, char *buf, size_t buf_size_in_bytes) {
@@ -1556,7 +1556,7 @@ char * json_serialize_to_string(const JSON_Value *value) {
 size_t json_serialization_size_pretty(const JSON_Value *value) {
     char num_buf[NUM_BUF_SIZE]; /* recursively allocating buffer on stack is a bad idea, so let's do it only once */
     int res = json_serialize_to_buffer_r(value, NULL, 0, 1, num_buf);
-    return res < 0 ? 0 : (size_t)(res + 1);
+    return res < 0 ? 0 : (size_t)(res) + 1;
 }
 
 JSON_Status json_serialize_to_buffer_pretty(const JSON_Value *value, char *buf, size_t buf_size_in_bytes) {

--- a/parson.h
+++ b/parson.h
@@ -1,7 +1,7 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson 1.0.1 ( http://kgabis.github.com/parson/ )
+ Parson 1.0.2 ( http://kgabis.github.com/parson/ )
  Copyright (c) 2012 - 2019 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
If `int res` holds the value `INT_MAX` then adding `1` results in undefined behavior. To guard against this possibility, cast `res` to `size_t`, not the result of `res + 1`.

Fixes #132