### PR TITLE
Add support for string values with embedded '\0' characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 test
 *.o
+testcpp
+tests/test_2_serialized.txt
+tests/test_2_serialized_pretty.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(parson C)
 
 include (GNUInstallDirs)
 
-set(PARSON_VERSION 1.0.2)
+set(PARSON_VERSION 1.1.0)
 add_library(parson parson.c)
 target_include_directories(parson PUBLIC $<INSTALL_INTERFACE:include>)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2012 - 2019 Krzysztof Gabis
+Copyright (c) 2012 - 2020 Krzysztof Gabis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parson",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "repo": "kgabis/parson",
   "description": "Small json parser and reader",
   "keywords": [ "json", "parser" ],

--- a/parson.c
+++ b/parson.c
@@ -1,8 +1,8 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson 1.0.2 ( http://kgabis.github.com/parson/ )
- Copyright (c) 2012 - 2019 Krzysztof Gabis
+ Parson 1.1.0 ( http://kgabis.github.com/parson/ )
+ Copyright (c) 2012 - 2020 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/parson.h
+++ b/parson.h
@@ -114,6 +114,7 @@ JSON_Status json_validate(const JSON_Value *schema, const JSON_Value *value);
  */
 JSON_Value  * json_object_get_value  (const JSON_Object *object, const char *name);
 const char  * json_object_get_string (const JSON_Object *object, const char *name);
+size_t        json_object_get_string_len(const JSON_Object *object, const char *name);
 JSON_Object * json_object_get_object (const JSON_Object *object, const char *name);
 JSON_Array  * json_object_get_array  (const JSON_Object *object, const char *name);
 double        json_object_get_number (const JSON_Object *object, const char *name); /* returns 0 on fail */
@@ -125,6 +126,7 @@ int           json_object_get_boolean(const JSON_Object *object, const char *nam
  this way. */
 JSON_Value  * json_object_dotget_value  (const JSON_Object *object, const char *name);
 const char  * json_object_dotget_string (const JSON_Object *object, const char *name);
+size_t        json_object_dotget_string_len(const JSON_Object *object, const char *name);
 JSON_Object * json_object_dotget_object (const JSON_Object *object, const char *name);
 JSON_Array  * json_object_dotget_array  (const JSON_Object *object, const char *name);
 double        json_object_dotget_number (const JSON_Object *object, const char *name); /* returns 0 on fail */
@@ -148,6 +150,7 @@ int json_object_dothas_value_of_type(const JSON_Object *object, const char *name
  * json_object_set_value does not copy passed value so it shouldn't be freed afterwards. */
 JSON_Status json_object_set_value(JSON_Object *object, const char *name, JSON_Value *value);
 JSON_Status json_object_set_string(JSON_Object *object, const char *name, const char *string);
+JSON_Status json_object_set_string_with_len(JSON_Object *object, const char *name, const char *string, size_t len);
 JSON_Status json_object_set_number(JSON_Object *object, const char *name, double number);
 JSON_Status json_object_set_boolean(JSON_Object *object, const char *name, int boolean);
 JSON_Status json_object_set_null(JSON_Object *object, const char *name);
@@ -156,6 +159,7 @@ JSON_Status json_object_set_null(JSON_Object *object, const char *name);
  * json_object_dotset_value does not copy passed value so it shouldn't be freed afterwards. */
 JSON_Status json_object_dotset_value(JSON_Object *object, const char *name, JSON_Value *value);
 JSON_Status json_object_dotset_string(JSON_Object *object, const char *name, const char *string);
+JSON_Status json_object_dotset_string_with_len(JSON_Object *object, const char *name, const char *string, size_t len);
 JSON_Status json_object_dotset_number(JSON_Object *object, const char *name, double number);
 JSON_Status json_object_dotset_boolean(JSON_Object *object, const char *name, int boolean);
 JSON_Status json_object_dotset_null(JSON_Object *object, const char *name);
@@ -174,6 +178,7 @@ JSON_Status json_object_clear(JSON_Object *object);
  */
 JSON_Value  * json_array_get_value  (const JSON_Array *array, size_t index);
 const char  * json_array_get_string (const JSON_Array *array, size_t index);
+size_t        json_array_get_string_len(const JSON_Array *array, size_t index);
 JSON_Object * json_array_get_object (const JSON_Array *array, size_t index);
 JSON_Array  * json_array_get_array  (const JSON_Array *array, size_t index);
 double        json_array_get_number (const JSON_Array *array, size_t index); /* returns 0 on fail */
@@ -190,6 +195,7 @@ JSON_Status json_array_remove(JSON_Array *array, size_t i);
  * json_array_replace_value does not copy passed value so it shouldn't be freed afterwards. */
 JSON_Status json_array_replace_value(JSON_Array *array, size_t i, JSON_Value *value);
 JSON_Status json_array_replace_string(JSON_Array *array, size_t i, const char* string);
+JSON_Status json_array_replace_string_with_len(JSON_Array *array, size_t i, const char *string, size_t len);
 JSON_Status json_array_replace_number(JSON_Array *array, size_t i, double number);
 JSON_Status json_array_replace_boolean(JSON_Array *array, size_t i, int boolean);
 JSON_Status json_array_replace_null(JSON_Array *array, size_t i);
@@ -201,6 +207,7 @@ JSON_Status json_array_clear(JSON_Array *array);
  * json_array_append_value does not copy passed value so it shouldn't be freed afterwards. */
 JSON_Status json_array_append_value(JSON_Array *array, JSON_Value *value);
 JSON_Status json_array_append_string(JSON_Array *array, const char *string);
+JSON_Status json_array_append_string_with_len(JSON_Array *array, const char *string, size_t len);
 JSON_Status json_array_append_number(JSON_Array *array, double number);
 JSON_Status json_array_append_boolean(JSON_Array *array, int boolean);
 JSON_Status json_array_append_null(JSON_Array *array);
@@ -211,6 +218,7 @@ JSON_Status json_array_append_null(JSON_Array *array);
 JSON_Value * json_value_init_object (void);
 JSON_Value * json_value_init_array  (void);
 JSON_Value * json_value_init_string (const char *string); /* copies passed string */
+JSON_Value * json_value_init_string_with_len(const char *string, size_t length); /* copies passed string */
 JSON_Value * json_value_init_number (double number);
 JSON_Value * json_value_init_boolean(int boolean);
 JSON_Value * json_value_init_null   (void);
@@ -221,6 +229,7 @@ JSON_Value_Type json_value_get_type   (const JSON_Value *value);
 JSON_Object *   json_value_get_object (const JSON_Value *value);
 JSON_Array  *   json_value_get_array  (const JSON_Value *value);
 const char  *   json_value_get_string (const JSON_Value *value);
+size_t          json_value_get_string_len(const JSON_Value *value);
 double          json_value_get_number (const JSON_Value *value);
 int             json_value_get_boolean(const JSON_Value *value);
 JSON_Value  *   json_value_get_parent (const JSON_Value *value);
@@ -230,6 +239,7 @@ JSON_Value_Type json_type   (const JSON_Value *value);
 JSON_Object *   json_object (const JSON_Value *value);
 JSON_Array  *   json_array  (const JSON_Value *value);
 const char  *   json_string (const JSON_Value *value);
+size_t          json_string_len(const JSON_Value *value);
 double          json_number (const JSON_Value *value);
 int             json_boolean(const JSON_Value *value);
 

--- a/parson.h
+++ b/parson.h
@@ -1,8 +1,8 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson 1.0.2 ( http://kgabis.github.com/parson/ )
- Copyright (c) 2012 - 2019 Krzysztof Gabis
+ Parson 1.1.0 ( http://kgabis.github.com/parson/ )
+ Copyright (c) 2012 - 2020 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -114,7 +114,7 @@ JSON_Status json_validate(const JSON_Value *schema, const JSON_Value *value);
  */
 JSON_Value  * json_object_get_value  (const JSON_Object *object, const char *name);
 const char  * json_object_get_string (const JSON_Object *object, const char *name);
-size_t        json_object_get_string_len(const JSON_Object *object, const char *name);
+size_t        json_object_get_string_len(const JSON_Object *object, const char *name); /* doesn't account for last null character */
 JSON_Object * json_object_get_object (const JSON_Object *object, const char *name);
 JSON_Array  * json_object_get_array  (const JSON_Object *object, const char *name);
 double        json_object_get_number (const JSON_Object *object, const char *name); /* returns 0 on fail */
@@ -126,7 +126,7 @@ int           json_object_get_boolean(const JSON_Object *object, const char *nam
  this way. */
 JSON_Value  * json_object_dotget_value  (const JSON_Object *object, const char *name);
 const char  * json_object_dotget_string (const JSON_Object *object, const char *name);
-size_t        json_object_dotget_string_len(const JSON_Object *object, const char *name);
+size_t        json_object_dotget_string_len(const JSON_Object *object, const char *name); /* doesn't account for last null character */
 JSON_Object * json_object_dotget_object (const JSON_Object *object, const char *name);
 JSON_Array  * json_object_dotget_array  (const JSON_Object *object, const char *name);
 double        json_object_dotget_number (const JSON_Object *object, const char *name); /* returns 0 on fail */
@@ -150,7 +150,7 @@ int json_object_dothas_value_of_type(const JSON_Object *object, const char *name
  * json_object_set_value does not copy passed value so it shouldn't be freed afterwards. */
 JSON_Status json_object_set_value(JSON_Object *object, const char *name, JSON_Value *value);
 JSON_Status json_object_set_string(JSON_Object *object, const char *name, const char *string);
-JSON_Status json_object_set_string_with_len(JSON_Object *object, const char *name, const char *string, size_t len);
+JSON_Status json_object_set_string_with_len(JSON_Object *object, const char *name, const char *string, size_t len);  /* length shouldn't include last null character */
 JSON_Status json_object_set_number(JSON_Object *object, const char *name, double number);
 JSON_Status json_object_set_boolean(JSON_Object *object, const char *name, int boolean);
 JSON_Status json_object_set_null(JSON_Object *object, const char *name);
@@ -159,7 +159,7 @@ JSON_Status json_object_set_null(JSON_Object *object, const char *name);
  * json_object_dotset_value does not copy passed value so it shouldn't be freed afterwards. */
 JSON_Status json_object_dotset_value(JSON_Object *object, const char *name, JSON_Value *value);
 JSON_Status json_object_dotset_string(JSON_Object *object, const char *name, const char *string);
-JSON_Status json_object_dotset_string_with_len(JSON_Object *object, const char *name, const char *string, size_t len);
+JSON_Status json_object_dotset_string_with_len(JSON_Object *object, const char *name, const char *string, size_t len); /* length shouldn't include last null character */
 JSON_Status json_object_dotset_number(JSON_Object *object, const char *name, double number);
 JSON_Status json_object_dotset_boolean(JSON_Object *object, const char *name, int boolean);
 JSON_Status json_object_dotset_null(JSON_Object *object, const char *name);
@@ -178,7 +178,7 @@ JSON_Status json_object_clear(JSON_Object *object);
  */
 JSON_Value  * json_array_get_value  (const JSON_Array *array, size_t index);
 const char  * json_array_get_string (const JSON_Array *array, size_t index);
-size_t        json_array_get_string_len(const JSON_Array *array, size_t index);
+size_t        json_array_get_string_len(const JSON_Array *array, size_t index); /* doesn't account for last null character */
 JSON_Object * json_array_get_object (const JSON_Array *array, size_t index);
 JSON_Array  * json_array_get_array  (const JSON_Array *array, size_t index);
 double        json_array_get_number (const JSON_Array *array, size_t index); /* returns 0 on fail */
@@ -195,7 +195,7 @@ JSON_Status json_array_remove(JSON_Array *array, size_t i);
  * json_array_replace_value does not copy passed value so it shouldn't be freed afterwards. */
 JSON_Status json_array_replace_value(JSON_Array *array, size_t i, JSON_Value *value);
 JSON_Status json_array_replace_string(JSON_Array *array, size_t i, const char* string);
-JSON_Status json_array_replace_string_with_len(JSON_Array *array, size_t i, const char *string, size_t len);
+JSON_Status json_array_replace_string_with_len(JSON_Array *array, size_t i, const char *string, size_t len); /* length shouldn't include last null character */
 JSON_Status json_array_replace_number(JSON_Array *array, size_t i, double number);
 JSON_Status json_array_replace_boolean(JSON_Array *array, size_t i, int boolean);
 JSON_Status json_array_replace_null(JSON_Array *array, size_t i);
@@ -207,7 +207,7 @@ JSON_Status json_array_clear(JSON_Array *array);
  * json_array_append_value does not copy passed value so it shouldn't be freed afterwards. */
 JSON_Status json_array_append_value(JSON_Array *array, JSON_Value *value);
 JSON_Status json_array_append_string(JSON_Array *array, const char *string);
-JSON_Status json_array_append_string_with_len(JSON_Array *array, const char *string, size_t len);
+JSON_Status json_array_append_string_with_len(JSON_Array *array, const char *string, size_t len); /* length shouldn't include last null character */
 JSON_Status json_array_append_number(JSON_Array *array, double number);
 JSON_Status json_array_append_boolean(JSON_Array *array, int boolean);
 JSON_Status json_array_append_null(JSON_Array *array);
@@ -218,7 +218,7 @@ JSON_Status json_array_append_null(JSON_Array *array);
 JSON_Value * json_value_init_object (void);
 JSON_Value * json_value_init_array  (void);
 JSON_Value * json_value_init_string (const char *string); /* copies passed string */
-JSON_Value * json_value_init_string_with_len(const char *string, size_t length); /* copies passed string */
+JSON_Value * json_value_init_string_with_len(const char *string, size_t length); /* copies passed string, length shouldn't include last null character */
 JSON_Value * json_value_init_number (double number);
 JSON_Value * json_value_init_boolean(int boolean);
 JSON_Value * json_value_init_null   (void);
@@ -229,7 +229,7 @@ JSON_Value_Type json_value_get_type   (const JSON_Value *value);
 JSON_Object *   json_value_get_object (const JSON_Value *value);
 JSON_Array  *   json_value_get_array  (const JSON_Value *value);
 const char  *   json_value_get_string (const JSON_Value *value);
-size_t          json_value_get_string_len(const JSON_Value *value);
+size_t          json_value_get_string_len(const JSON_Value *value); /* doesn't account for last null character */
 double          json_value_get_number (const JSON_Value *value);
 int             json_value_get_boolean(const JSON_Value *value);
 JSON_Value  *   json_value_get_parent (const JSON_Value *value);
@@ -239,7 +239,7 @@ JSON_Value_Type json_type   (const JSON_Value *value);
 JSON_Object *   json_object (const JSON_Value *value);
 JSON_Array  *   json_array  (const JSON_Value *value);
 const char  *   json_string (const JSON_Value *value);
-size_t          json_string_len(const JSON_Value *value);
+size_t          json_string_len(const JSON_Value *value); /* doesn't account for last null character */
 double          json_number (const JSON_Value *value);
 int             json_boolean(const JSON_Value *value);
 

--- a/tests.c
+++ b/tests.c
@@ -2,7 +2,7 @@
  SPDX-License-Identifier: MIT
 
  Parson ( http://kgabis.github.com/parson/ )
- Copyright (c) 2012 - 2019 Krzysztof Gabis
+ Copyright (c) 2012 - 2020 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal

--- a/tests.c
+++ b/tests.c
@@ -136,6 +136,7 @@ void test_suite_2(JSON_Value *root_value) {
     JSON_Object *root_object;
     JSON_Array *array;
     JSON_Value *array_value;
+    size_t len;
     size_t i;
     TEST(root_value);
     TEST(json_value_get_type(root_value) == JSONObject);
@@ -175,6 +176,10 @@ void test_suite_2(JSON_Value *root_value) {
     TEST(STREQ(json_object_get_string(root_object, "utf string"), "lorem ipsum"));
     TEST(STREQ(json_object_get_string(root_object, "utf-8 string"), "あいうえお"));
     TEST(STREQ(json_object_get_string(root_object, "surrogate string"), "lorem𝄞ipsum𝍧lorem"));
+
+    len = json_object_get_string_len(root_object, "string with null");
+    TEST(len == 7);
+    TEST(memcmp(json_object_get_string(root_object, "string with null"), "abc\0def", len) == 0);
 
     TEST(json_object_get_number(root_object, "positive one") == 1.0);
     TEST(json_object_get_number(root_object, "negative one") == -1.0);
@@ -370,6 +375,7 @@ void test_suite_5(void) {
     TEST(json_object_set_string(obj, "utf string", "lorem ipsum") == JSONSuccess);
     TEST(json_object_set_string(obj, "utf-8 string", "あいうえお") == JSONSuccess);
     TEST(json_object_set_string(obj, "surrogate string", "lorem𝄞ipsum𝍧lorem") == JSONSuccess);
+    TEST(json_object_set_string_with_len(obj, "string with null", "abc\0def", 7) == JSONSuccess);
     TEST(json_object_set_string(obj, "windows path", "C:\\Windows\\Path") == JSONSuccess);
     TEST(json_value_equals(val_from_file, val));
 

--- a/tests/test_1_1.txt
+++ b/tests/test_1_1.txt
@@ -26,6 +26,7 @@
         "digit": "0123456789",
         "0123456789": "digit",
         "special": "`1~!@#$%^&*()_+-={':[,]}|;.</>?",
+        "nullchar": "abc\u0000def",
         "hex": "\u0123\u4567\u89AB\uCDEF\uabcd\uef4A",
         "true": true,
         "false": false,

--- a/tests/test_2.txt
+++ b/tests/test_2.txt
@@ -3,6 +3,7 @@
     "utf string" : "\u006corem\u0020ipsum",
     "utf-8 string": "あいうえお",
     "surrogate string": "lorem\uD834\uDD1Eipsum\uD834\uDF67lorem",
+    "string with null": "abc\u0000def",
     "positive one" : 1,
     "negative one" : -1,
     "pi" : 3.14,

--- a/tests/test_2_comments.txt
+++ b/tests/test_2_comments.txt
@@ -9,6 +9,7 @@
 	"utf string" : "\u006corem\u0020ipsum", // lorem ipsum //
    "utf-8 string": "あいうえお", // /* lorem ipsum */
     "surrogate string": "lorem\uD834\uDD1Eipsum\uD834\uDF67lorem",
+    "string with null": "abc\u0000def",
 	"positive one" : 1, 
 	"negative one" : -1,
 	"pi" : 3.14,

--- a/tests/test_2_pretty.txt
+++ b/tests/test_2_pretty.txt
@@ -3,6 +3,7 @@
     "utf string": "lorem ipsum",
     "utf-8 string": "あいうえお",
     "surrogate string": "lorem𝄞ipsum𝍧lorem",
+    "string with null": "abc\u0000def",
     "positive one": 1,
     "negative one": -1,
     "pi": 3.1400000000000001,

--- a/tests/test_5.txt
+++ b/tests/test_5.txt
@@ -11,5 +11,6 @@
   "utf string" : "\u006corem\u0020ipsum",
   "utf-8 string": "あいうえお",
   "surrogate string": "lorem\uD834\uDD1Eipsum\uD834\uDF67lorem",
+  "string with null": "abc\u0000def",
   "windows path": "C:\\Windows\\Path"
 }


### PR DESCRIPTION
It is valid for a JSON string value to contain an embedded, encoded `\u0000` character within it (a.k.a. `NUL`, a.k.a. `'\0'`).  This change additively introduces basic support in parson to correctly manipulate such string values, *should the client care to do so*.  Existing callers will continue to see the same behavior (i.e. an apparently truncated string value) if they call the existing APIs and assume the returned string is a simple `'\0'`-terminated character array.

Specifically, for each existing public `json..._get_string` function, this change introduces a companion `json..._get_string_len` function to retrieve the length of the string value.  Similarly, for each `json..._set_string` function, this change introduces a `json..._set_string_with_len` function that takes both a `const char *` as well as a length.  This preserves existing function signatures and contracts with no breaking changes.

Note that this change does *not* add support for object keys to contain embedded, encoded `\u0000` characters.  I looked into making that change, but noted that it would require forking all of the existing public APIs for retrieving a value from an object by key; for now, I've left behind a comment in the code explaining where we assume that parson does not support keys containing these characters.

This change also includes additions to internal parson tests to validate parsing, serialization, round-tripping, etc. of string values containing `\u0000` encoded chars.