### PR TITLE
Remove redundant code

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -991,9 +991,6 @@ static int json_serialize_to_buffer_r(const JSON_Value *value, char *buf, int le
             if (written < 0) {
                 return -1;
             }
-            if (buf != NULL) {
-                buf += written;
-            }
             written_total += written;
             return written_total;
         case JSONBoolean:
@@ -1011,9 +1008,6 @@ static int json_serialize_to_buffer_r(const JSON_Value *value, char *buf, int le
             written = sprintf(num_buf, FLOAT_FORMAT, num);
             if (written < 0) {
                 return -1;
-            }
-            if (buf != NULL) {
-                buf += written;
             }
             written_total += written;
             return written_total;


### PR DESCRIPTION
Found by clang-check.
(the last one looks like a false-positive to me)

parson.c:995:17: warning: Value stored to 'buf' is never read
                buf += written;
                ^      ~~~~~~~
parson.c:1016:17: warning: Value stored to 'buf' is never read
                buf += written;
                ^      ~~~~~~~
parson.c:1834:24: warning: Array access (via field 'names') results in a null pointer dereference
            if (strcmp(object->names[i], name) == 0) {
                       ^~~~~~~~~~~~~~~~
3 warnings generated.