### PR TITLE
Resolve conversion warnings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
 CC = gcc
-CFLAGS = -O0 -g -Wall -Wextra -std=c89 -pedantic-errors
+CFLAGS = -O0 -g -Wall -Wextra -Wconversion -std=c89 -pedantic-errors
 
 CPPC = g++
-CPPFLAGS = -O0 -g -Wall -Wextra
+CPPFLAGS = -O0 -g -Wall -Wextra -Wconversion
 
-all: test testcpp
+all: test testcpp parson
 
-.PHONY: test testcpp
+.PHONY: test testcpp parson
+
+parson: parson.o
+parson.o: parson.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
 test: tests.c parson.c
 	$(CC) $(CFLAGS) -o $@ tests.c parson.c
 	./$@

--- a/parson.c
+++ b/parson.c
@@ -297,7 +297,7 @@ static char * read_file(const char * filename) {
         fclose(fp);
         return NULL;
     }
-    size_to_read = pos;
+    size_to_read = (size_t)pos;
     rewind(fp);
     file_contents = (char*)parson_malloc(sizeof(char) * (size_to_read + 1));
     if (!file_contents) {
@@ -340,7 +340,7 @@ static void remove_comments(char *string, const char *start_token, const char *e
             if (!ptr) {
                 return;
             }
-            for (i = 0; i < (ptr - string) + end_token_len; i++) {
+            for (i = 0; i < (size_t)(ptr - string) + end_token_len; i++) {
                 string[i] = ' ';
             }
             string = ptr + end_token_len - 1;
@@ -470,7 +470,7 @@ static JSON_Status json_object_dotremove_internal(JSON_Object *object, const cha
     if (dot_pos == NULL) {
         return json_object_remove_internal(object, name, free_value);
     }
-    temp_value = json_object_getn_value(object, name, dot_pos - name);
+    temp_value = json_object_getn_value(object, name, (size_t)(dot_pos - name));
     if (json_value_get_type(temp_value) != JSONObject) {
         return JSONFailure;
     }
@@ -589,13 +589,13 @@ static int parse_utf16(const char **unprocessed, char **processed) {
     if (cp < 0x80) {
         processed_ptr[0] = (char)cp; /* 0xxxxxxx */
     } else if (cp < 0x800) {
-        processed_ptr[0] = ((cp >> 6) & 0x1F) | 0xC0; /* 110xxxxx */
-        processed_ptr[1] = ((cp)      & 0x3F) | 0x80; /* 10xxxxxx */
+        processed_ptr[0] = (char)(((cp >> 6) & 0x1F) | 0xC0); /* 110xxxxx */
+        processed_ptr[1] = (char)(((cp)      & 0x3F) | 0x80); /* 10xxxxxx */
         processed_ptr += 1;
     } else if (cp < 0xD800 || cp > 0xDFFF) {
-        processed_ptr[0] = ((cp >> 12) & 0x0F) | 0xE0; /* 1110xxxx */
-        processed_ptr[1] = ((cp >> 6)  & 0x3F) | 0x80; /* 10xxxxxx */
-        processed_ptr[2] = ((cp)       & 0x3F) | 0x80; /* 10xxxxxx */
+        processed_ptr[0] = (char)(((cp >> 12) & 0x0F) | 0xE0); /* 1110xxxx */
+        processed_ptr[1] = (char)(((cp >> 6)  & 0x3F) | 0x80); /* 10xxxxxx */
+        processed_ptr[2] = (char)(((cp)       & 0x3F) | 0x80); /* 10xxxxxx */
         processed_ptr += 2;
     } else if (cp >= 0xD800 && cp <= 0xDBFF) { /* lead surrogate (0xD800..0xDBFF) */
         lead = cp;
@@ -608,10 +608,10 @@ static int parse_utf16(const char **unprocessed, char **processed) {
             return JSONFailure;
         }
         cp = ((((lead - 0xD800) & 0x3FF) << 10) | ((trail - 0xDC00) & 0x3FF)) + 0x010000;
-        processed_ptr[0] = (((cp >> 18) & 0x07) | 0xF0); /* 11110xxx */
-        processed_ptr[1] = (((cp >> 12) & 0x3F) | 0x80); /* 10xxxxxx */
-        processed_ptr[2] = (((cp >> 6)  & 0x3F) | 0x80); /* 10xxxxxx */
-        processed_ptr[3] = (((cp)       & 0x3F) | 0x80); /* 10xxxxxx */
+        processed_ptr[0] = (char)(((cp >> 18) & 0x07) | 0xF0); /* 11110xxx */
+        processed_ptr[1] = (char)(((cp >> 12) & 0x3F) | 0x80); /* 10xxxxxx */
+        processed_ptr[2] = (char)(((cp >> 6)  & 0x3F) | 0x80); /* 10xxxxxx */
+        processed_ptr[3] = (char)(((cp)       & 0x3F) | 0x80); /* 10xxxxxx */
         processed_ptr += 3;
     } else { /* trail surrogate before lead surrogate */
         return JSONFailure;
@@ -689,7 +689,7 @@ static char * get_quoted_string(const char **string, size_t *output_string_len) 
     if (status != JSONSuccess) {
         return NULL;
     }
-    input_string_len = *string - string_start - 2; /* length without quotes */
+    input_string_len = (size_t)(*string - string_start - 2); /* length without quotes */
     return process_string(string_start + 1, input_string_len, output_string_len);
 }
 
@@ -861,7 +861,7 @@ static JSON_Value * parse_number_value(const char **string) {
     double number = 0;
     errno = 0;
     number = strtod(*string, &end);
-    if (errno || !is_decimal(*string, end - *string)) {
+    if (errno || !is_decimal(*string, (size_t)(end - *string))) {
         return NULL;
     }
     *string = end;
@@ -1199,7 +1199,7 @@ JSON_Value * json_object_dotget_value(const JSON_Object *object, const char *nam
     if (!dot_position) {
         return json_object_get_value(object, name);
     }
-    object = json_value_get_object(json_object_getn_value(object, name, dot_position - name));
+    object = json_value_get_object(json_object_getn_value(object, name, (size_t)(dot_position - name)));
     return json_object_dotget_value(object, dot_position + 1);
 }
 
@@ -1900,7 +1900,7 @@ JSON_Status json_object_dotset_value(JSON_Object *object, const char *name, JSON
     if (dot_pos == NULL) {
         return json_object_set_value(object, name, value);
     }
-    name_len = dot_pos - name;
+    name_len = (size_t)(dot_pos - name);
     temp_value = json_object_getn_value(object, name, name_len);
     if (temp_value) {
         /* Don't overwrite existing non-object (unlike json_object_set_value, but it shouldn't be changed at this point) */

--- a/tests.c
+++ b/tests.c
@@ -199,7 +199,7 @@ void test_suite_2(JSON_Value *root_value) {
     array = json_object_get_array(root_object, "x^2 array");
     if (array != NULL) {
         for (i = 0; i < json_array_get_count(array); i++) {
-            TEST(json_array_get_number(array, i) == (i * i));
+            TEST((size_t)json_array_get_number(array, i) == (i * i));
         }
     } else {
         tests_failed++;
@@ -683,7 +683,7 @@ static char * read_file(const char * file_path) {
         assert(0);
         return NULL;
     }
-    size_to_read = pos;
+    size_to_read = (size_t)pos;
     rewind(fp);
     file_contents = (char*)malloc(sizeof(char) * (size_to_read + 1));
     if (!file_contents) {


### PR DESCRIPTION
Resolve conversion warnings when -Wconversion is added to the compiler
arguments.