### PR TITLE
is_decimal: Fix an integer underflow.

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -274,7 +274,8 @@ static int is_decimal(const char *string, size_t length) {
     if (length > 2 && !strncmp(string, "-0", 2) && string[2] != '.') {
         return 0;
     }
-    while (length--) {
+    while (length) {
+        length--;
         if (strchr("xX", string[length])) {
             return 0;
         }


### PR DESCRIPTION
It seems harmless though.

Found by UBSAN

parson.c:270:18: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'size_t' (aka 'unsigned long')