### PR TITLE
docs: fix simple typo, lighweight -> lightweight

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## About
-Parson is a lighweight [json](http://json.org) library written in C.
+Parson is a lightweight [json](http://json.org) library written in C.
 
 ## Features
 * Full JSON support


### PR DESCRIPTION
There is a small typo in README.md.

Should read `lightweight` rather than `lighweight`.

