### PR TITLE
Fix memleak when parsing keys with embedded null bytes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(parson C)
 
 include (GNUInstallDirs)
 
-set(PARSON_VERSION 1.1.1)
+set(PARSON_VERSION 1.1.2)
 add_library(parson parson.c)
 target_include_directories(parson PUBLIC $<INSTALL_INTERFACE:include>)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parson",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "repo": "kgabis/parson",
   "description": "Small json parser and reader",
   "keywords": [ "json", "parser" ],

--- a/parson.c
+++ b/parson.c
@@ -742,6 +742,9 @@ static JSON_Value * parse_object_value(const char **string, size_t nesting) {
         new_key = get_quoted_string(string, &key_len);
         /* We do not support key names with embedded \0 chars */
         if (new_key == NULL || key_len != strlen(new_key)) {
+            if (new_key) {
+                parson_free(new_key);
+            }
             json_value_free(output_value);
             return NULL;
         }

--- a/parson.c
+++ b/parson.c
@@ -1,7 +1,7 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson 1.1.1 ( http://kgabis.github.com/parson/ )
+ Parson 1.1.2 ( http://kgabis.github.com/parson/ )
  Copyright (c) 2012 - 2021 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/parson.h
+++ b/parson.h
@@ -1,7 +1,7 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson 1.1.1 ( http://kgabis.github.com/parson/ )
+ Parson 1.1.2 ( http://kgabis.github.com/parson/ )
  Copyright (c) 2012 - 2021 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/tests.c
+++ b/tests.c
@@ -588,6 +588,8 @@ void test_memory_leaks() {
     TEST(json_object_set_boolean(NULL, "lorem", 0) == JSONFailure);
     TEST(json_object_set_null(NULL, "lorem") == JSONFailure);
 
+    TEST(json_parse_string("{\"\\u0000\"") == NULL);
+
     TEST(malloc_count == 0);
 }
 


### PR DESCRIPTION
This commit fixes and adds a test for a memory leak that occurs when
parsing strings with keys that have a null byte embedded in them.

This memory leak can be triggered with the following line, where this
call returns a `NULL`:
```c
        json_parse_string("{\"\\u0000\"")
```

This memory leak happens in the `parse_object_value` function in here:
```c
        new_key = get_quoted_string(string, &key_len);  // <---- ALLOCATION
        /* We do not support key names with embedded \0 chars */
        if (new_key == NULL || key_len != strlen(new_key)) {
            json_value_free(output_value);
            return NULL;                       // <---- `new_key` NOT FREED
        }
        SKIP_WHITESPACES(string);
        if (**string != ':') {
            parson_free(new_key);
            json_value_free(output_value);
            return NULL;
        }
```