### PR TITLE
Gitignore test_hash_collisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test
 testcpp
 tests/test_2_serialized.txt
 tests/test_2_serialized_pretty.txt
+test_hash_collisions


### PR DESCRIPTION
Add test_hash_collisions to the gitignore, as it is created during `make test_hash_collisions` or a generic `make`.