### PR TITLE
Build break: Fixing size_t conversion on x64 systems. Excluding build/ in .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ testcpp
 tests/test_2_serialized.txt
 tests/test_2_serialized_pretty.txt
 test_hash_collisions
+build/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(parson C)
 
 include (GNUInstallDirs)
 
-set(PARSON_VERSION 1.3.0)
+set(PARSON_VERSION 1.3.1)
 add_library(parson parson.c)
 target_include_directories(parson PUBLIC $<INSTALL_INTERFACE:include>)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parson",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "repo": "kgabis/parson",
   "description": "Small json parser and reader",
   "keywords": [ "json", "parser" ],

--- a/parson.c
+++ b/parson.c
@@ -596,7 +596,7 @@ static JSON_Status json_object_add(JSON_Object *object, char *name, JSON_Value *
 static JSON_Value * json_object_getn_value(const JSON_Object *object, const char *name, size_t name_len) {
     unsigned long hash = 0;
     parson_bool_t found = PARSON_FALSE;
-    unsigned long cell_ix = 0;
+    size_t cell_ix = 0;
     size_t item_ix = 0;
     if (!object || !name) {
         return NULL;

--- a/parson.c
+++ b/parson.c
@@ -1,7 +1,7 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson 1.3.0 (https://github.com/kgabis/parson)
+ Parson 1.3.1 (https://github.com/kgabis/parson)
  Copyright (c) 2012 - 2022 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -32,7 +32,7 @@
 
 #define PARSON_IMPL_VERSION_MAJOR 1
 #define PARSON_IMPL_VERSION_MINOR 3
-#define PARSON_IMPL_VERSION_PATCH 0
+#define PARSON_IMPL_VERSION_PATCH 1
 
 #if (PARSON_VERSION_MAJOR != PARSON_IMPL_VERSION_MAJOR)\
 || (PARSON_VERSION_MINOR != PARSON_IMPL_VERSION_MINOR)\

--- a/parson.h
+++ b/parson.h
@@ -1,7 +1,7 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson 1.3.0 (https://github.com/kgabis/parson)
+ Parson 1.3.1 (https://github.com/kgabis/parson)
  Copyright (c) 2012 - 2022 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -36,9 +36,9 @@ extern "C"
 
 #define PARSON_VERSION_MAJOR 1
 #define PARSON_VERSION_MINOR 3
-#define PARSON_VERSION_PATCH 0
+#define PARSON_VERSION_PATCH 1
 
-#define PARSON_VERSION_STRING "1.3.0"
+#define PARSON_VERSION_STRING "1.3.1"
 
 #include <stddef.h>   /* size_t */
 


### PR DESCRIPTION
1. Fixing this build break on Windows x64:

```   
D:\a\_work\1\s\deps\parson\parson.c(599): warning C4267: '=': conversion from 'size_t' to 'unsigned long', possible loss of data [D:\a\_work\1\s\cmake\deps\parson\parson.vcxproj]
```

2. Excluding the `\build` folder (commonly used for cmake generation) in `.gitignore`.