### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ and copy parson.h and parson.c to you source code tree.
 
 Run ```make test``` to compile and run tests.
 
+Alternatively, you can build and install parson using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+```
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh # "./bootstrap-vcpkg.bat" for powershell
+./vcpkg integrate install
+./vcpkg install parson
+```
+
+The parson port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Examples
 ### Parsing JSON
 Here is a function, which prints basic commit info (date, sha and author) from a github repository.  


### PR DESCRIPTION
`parson` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `parson` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `parson`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/parson/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)