### PR TITLE
misc improvements to json_serialize_to_buffer() performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(parson C)
 
 include (GNUInstallDirs)
 
-set(PARSON_VERSION 1.4.0)
+set(PARSON_VERSION 1.5.0)
 add_library(parson parson.c)
 target_include_directories(parson PUBLIC $<INSTALL_INTERFACE:include>)
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('parson', 'c',
-    version : '1.4.0', # !!! also increment lib_so_version !!!
+    version : '1.5.0',
     license : 'MIT',
     meson_version : '>=0.46.0',
     default_options : [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parson",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "repo": "kgabis/parson",
   "description": "Small json parser and reader",
   "keywords": [ "json", "parser" ],

--- a/parson.c
+++ b/parson.c
@@ -94,6 +94,8 @@ static int parson_escape_slashes = 1;
 
 static char *parson_float_format = NULL;
 
+static JSON_Float_Serializer_Function parson_float_serializer_function = NULL;
+
 #define IS_CONT(b) (((unsigned char)(b) & 0xC0) == 0x80) /* is utf-8 continuation byte */
 
 typedef int parson_bool_t;
@@ -1232,7 +1234,9 @@ static int json_serialize_to_buffer_r(const JSON_Value *value, char *buf, int le
             if (buf != NULL) {
                 num_buf = buf;
             }
-            if (parson_float_format) {
+            if (parson_float_serializer_function) {
+                written = parson_float_serializer_function(num, num_buf);
+            } else if (parson_float_format) {
                 written = sprintf(num_buf, parson_float_format, num);
             } else {
                 written = sprintf(num_buf, PARSON_DEFAULT_FLOAT_FORMAT, num);
@@ -2440,4 +2444,8 @@ void json_set_float_serialization_format(const char *format) {
         return;
     }
     parson_float_format = parson_strdup(format);
+}
+
+void json_set_float_serialization_function(JSON_Float_Serializer_Function func) {
+    parson_float_serializer_function = func;
 }

--- a/parson.c
+++ b/parson.c
@@ -1128,8 +1128,8 @@ static int json_serialize_to_buffer_r(const JSON_Value *value, char *buf, int le
 
     switch (json_value_get_type(value)) {
         case JSONArray:
-            array = json_value_get_array(value);
-            count = json_array_get_count(array);
+            array = value->value.array;
+            count = array->count;
             APPEND_STRING("[");
             if (count > 0 && is_pretty) {
                 APPEND_STRING("\n");
@@ -1138,7 +1138,7 @@ static int json_serialize_to_buffer_r(const JSON_Value *value, char *buf, int le
                 if (is_pretty) {
                     APPEND_INDENT(level+1);
                 }
-                temp_value = json_array_get_value(array, i);
+                temp_value = array->items[i];
                 written = json_serialize_to_buffer_r(temp_value, buf, level+1, is_pretty, num_buf);
                 if (written < 0) {
                     return -1;
@@ -1160,14 +1160,14 @@ static int json_serialize_to_buffer_r(const JSON_Value *value, char *buf, int le
             APPEND_STRING("]");
             return written_total;
         case JSONObject:
-            object = json_value_get_object(value);
-            count  = json_object_get_count(object);
+            object = value->value.object;
+            count  = object->count;
             APPEND_STRING("{");
             if (count > 0 && is_pretty) {
                 APPEND_STRING("\n");
             }
             for (i = 0; i < count; i++) {
-                key = json_object_get_name(object, i);
+                key = object->names[i];
                 if (key == NULL) {
                     return -1;
                 }
@@ -1187,7 +1187,7 @@ static int json_serialize_to_buffer_r(const JSON_Value *value, char *buf, int le
                 if (is_pretty) {
                     APPEND_STRING(" ");
                 }
-                temp_value = json_object_get_value_at(object, i);
+                temp_value = object->values[i];
                 written = json_serialize_to_buffer_r(temp_value, buf, level+1, is_pretty, num_buf);
                 if (written < 0) {
                     return -1;
@@ -1209,11 +1209,8 @@ static int json_serialize_to_buffer_r(const JSON_Value *value, char *buf, int le
             APPEND_STRING("}");
             return written_total;
         case JSONString:
-            string = json_value_get_string(value);
-            if (string == NULL) {
-                return -1;
-            }
-            len = json_value_get_string_len(value);
+            string = value->value.string.chars;
+            len = value->value.string.length;
             written = json_serialize_string(string, len, buf);
             if (written < 0) {
                 return -1;
@@ -1224,14 +1221,14 @@ static int json_serialize_to_buffer_r(const JSON_Value *value, char *buf, int le
             written_total += written;
             return written_total;
         case JSONBoolean:
-            if (json_value_get_boolean(value)) {
+            if (value->value.boolean) {
                 APPEND_STRING("true");
             } else {
                 APPEND_STRING("false");
             }
             return written_total;
         case JSONNumber:
-            num = json_value_get_number(value);
+            num = value->value.number;
             if (buf != NULL) {
                 num_buf = buf;
             }

--- a/parson.c
+++ b/parson.c
@@ -192,7 +192,6 @@ static JSON_Value *  parse_value(const char **string, size_t nesting);
 /* Serialization */
 static int json_serialize_to_buffer_r(const JSON_Value *value, char *buf, int level, parson_bool_t is_pretty, char *num_buf);
 static int json_serialize_string(const char *string, size_t len, char *buf);
-static int append_indent(char *buf, int level);
 
 /* Various */
 static char * read_file(const char * filename) {
@@ -1104,9 +1103,16 @@ static JSON_Value * parse_null_value(const char **string) {
                                 }\
                                 written_total += written; } while(0)
 
-#define APPEND_INDENT(level) do { written = append_indent(buf, (level));\
-                                  if (written < 0) { return -1; }\
-                                  if (buf != NULL) { buf += written; }\
+#define INDENT_STR ("    ")
+#define APPEND_INDENT(level) do { written = SIZEOF_TOKEN(INDENT_STR) * (level);\
+                                  if (written > 0 && buf != NULL) {\
+                                      int i;\
+                                      for (i = 0; i < level; i++) {\
+                                          memcpy((buf), INDENT_STR, SIZEOF_TOKEN(INDENT_STR));\
+                                          buf += SIZEOF_TOKEN(INDENT_STR);\
+                                      }\
+                                      buf[(written)] = '\0';\
+                                  }\
                                   written_total += written; } while(0)
 
 static int json_serialize_to_buffer_r(const JSON_Value *value, char *buf, int level, parson_bool_t is_pretty, char *num_buf)
@@ -1316,15 +1322,6 @@ static int json_serialize_string(const char *string, size_t len, char *buf) {
         }
     }
     APPEND_STRING("\"");
-    return written_total;
-}
-
-static int append_indent(char *buf, int level) {
-    int i;
-    int written = -1, written_total = 0;
-    for (i = 0; i < level; i++) {
-        APPEND_STRING("    ");
-    }
     return written_total;
 }
 

--- a/parson.h
+++ b/parson.h
@@ -1,7 +1,7 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson 1.4.0 (https://github.com/kgabis/parson)
+ Parson 1.5.0 (https://github.com/kgabis/parson)
  Copyright (c) 2012 - 2022 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -35,10 +35,10 @@ extern "C"
 #endif
 
 #define PARSON_VERSION_MAJOR 1
-#define PARSON_VERSION_MINOR 4
+#define PARSON_VERSION_MINOR 5
 #define PARSON_VERSION_PATCH 0
 
-#define PARSON_VERSION_STRING "1.4.0"
+#define PARSON_VERSION_STRING "1.5.0"
 
 #include <stddef.h>   /* size_t */
 
@@ -67,15 +67,11 @@ typedef int JSON_Status;
 typedef void * (*JSON_Malloc_Function)(size_t);
 typedef void   (*JSON_Free_Function)(void *);
 
-/* Serializer function hook/callback that can be used instead of the
-   of the default one (sprintf()). It should have the same return
-   values as sprintf(). It has been found that sprintf() can be slow
-   on some embedded systems when needing to convert double to string,
-   so this gives users the ability to adapt their own version of
-   the serializer (for this type of data). Similarly as sprintf()
-   if 'buf' is null, the function should return the number of
-   bytes that should be allocated, but no more than PARSON_NUM_BUF_SIZE. */
-typedef int    (*JSON_Float_Serializer_Function)(double num, char *buf);
+/* A function used for serializing numbers (see json_set_number_serialization_function).
+   If 'buf' is null then it should return number of bytes that would've been written 
+   (but not more than PARSON_NUM_BUF_SIZE).
+*/
+typedef int (*JSON_Number_Serialization_Function)(double num, char *buf);
 
 /* Call only once, before calling any other function from parson API. If not called, malloc and free
    from stdlib will be used for all allocations */
@@ -90,9 +86,9 @@ void json_set_escape_slashes(int escape_slashes);
    If format is null then the default format is used. */
 void json_set_float_serialization_format(const char *format);
 
-/* Sets a function that will be used for float serialization of numbers.
-   If format is null then the default format is used. */
-void json_set_float_serialization_function(JSON_Float_Serializer_Function func);
+/* Sets a function that will be used for serialization of numbers.
+   If function is null then the default serialization function is used. */
+void json_set_number_serialization_function(JSON_Number_Serialization_Function fun);
 
 /* Parses first JSON value in a file, returns NULL in case of error */
 JSON_Value * json_parse_file(const char *filename);

--- a/parson.h
+++ b/parson.h
@@ -67,6 +67,16 @@ typedef int JSON_Status;
 typedef void * (*JSON_Malloc_Function)(size_t);
 typedef void   (*JSON_Free_Function)(void *);
 
+/* Serializer function hook/callback that can be used instead of the
+   of the default one (sprintf()). It should have the same return
+   values as sprintf(). It has been found that sprintf() can be slow
+   on some embedded systems when needing to convert double to string,
+   so this gives users the ability to adapt their own version of
+   the serializer (for this type of data). Similarly as sprintf()
+   if 'buf' is null, the function should return the number of
+   bytes that should be allocated, but no more than PARSON_NUM_BUF_SIZE. */
+typedef int    (*JSON_Float_Serializer_Function)(double num, char *buf);
+
 /* Call only once, before calling any other function from parson API. If not called, malloc and free
    from stdlib will be used for all allocations */
 void json_set_allocation_functions(JSON_Malloc_Function malloc_fun, JSON_Free_Function free_fun);
@@ -79,6 +89,10 @@ void json_set_escape_slashes(int escape_slashes);
    Make sure it can't serialize to a string longer than PARSON_NUM_BUF_SIZE.
    If format is null then the default format is used. */
 void json_set_float_serialization_format(const char *format);
+
+/* Sets a function that will be used for float serialization of numbers.
+   If format is null then the default format is used. */
+void json_set_float_serialization_function(JSON_Float_Serializer_Function func);
 
 /* Parses first JSON value in a file, returns NULL in case of error */
 JSON_Value * json_parse_file(const char *filename);

--- a/tests.c
+++ b/tests.c
@@ -63,7 +63,7 @@ void test_suite_11(void); /* Additional things that require testing */
 void test_memory_leaks(void);
 void test_failing_allocations(void);
 void test_custom_number_format(void);
-void test_custom_number_serializer_function(void);
+void test_custom_number_serialization_function(void);
 
 void print_commits_info(const char *username, const char *repo);
 void persistence_example(void);
@@ -133,7 +133,7 @@ int tests_main(int argc, char *argv[]) {
     test_memory_leaks();
     test_failing_allocations();
     test_custom_number_format();
-    test_custom_number_serializer_function();
+    test_custom_number_serialization_function();
 
     printf("Tests failed: %d\n", g_tests_failed);
     printf("Tests passed: %d\n", g_tests_passed);
@@ -706,24 +706,24 @@ void test_custom_number_format() {
     json_value_free(val);
 }
 
-static int custom_serializer_func_called = 0;
-static int custom_serializer_func(double num, char *buf) {
+static int custom_serialization_func_called = 0;
+static int custom_serialization_func(double num, char *buf) {
     char num_buf[32];
-    custom_serializer_func_called = 1;
+    custom_serialization_func_called = 1;
     if (buf == NULL)
         buf = num_buf;
     return sprintf(buf, "%.1f", num);
 }
 
-void test_custom_number_serializer_function() {
-    /* We just test that custom_serializer_func() gets called, not it's performance */
+void test_custom_number_serialization_function() {
+    /* We just test that custom_serialization_func() gets called, not it's performance */
     char *serialized = NULL;
     JSON_Value *val = json_value_init_number(0.6);
-    json_set_float_serialization_function(custom_serializer_func);
+    json_set_number_serialization_function(custom_serialization_func);
     serialized = json_serialize_to_string(val);
     TEST(STREQ(serialized, "0.6"));
-    TEST(custom_serializer_func_called);
-    json_set_float_serialization_function(NULL);
+    TEST(custom_serialization_func_called);
+    json_set_number_serialization_function(NULL);
     json_free_serialized_string(serialized);
     json_value_free(val);
 }

--- a/tests.c
+++ b/tests.c
@@ -63,6 +63,7 @@ void test_suite_11(void); /* Additional things that require testing */
 void test_memory_leaks(void);
 void test_failing_allocations(void);
 void test_custom_number_format(void);
+void test_custom_number_serializer_function(void);
 
 void print_commits_info(const char *username, const char *repo);
 void persistence_example(void);
@@ -132,6 +133,7 @@ int tests_main(int argc, char *argv[]) {
     test_memory_leaks();
     test_failing_allocations();
     test_custom_number_format();
+    test_custom_number_serializer_function();
 
     printf("Tests failed: %d\n", g_tests_failed);
     printf("Tests passed: %d\n", g_tests_passed);
@@ -700,6 +702,28 @@ void test_custom_number_format() {
     json_set_float_serialization_format("%.1f");
     serialized = json_serialize_to_string(val);
     TEST(STREQ(serialized, "0.6"));
+    json_free_serialized_string(serialized);
+    json_value_free(val);
+}
+
+static int custom_serializer_func_called = 0;
+static int custom_serializer_func(double num, char *buf) {
+    char num_buf[32];
+    custom_serializer_func_called = 1;
+    if (buf == NULL)
+        buf = num_buf;
+    return sprintf(buf, "%.1f", num);
+}
+
+void test_custom_number_serializer_function() {
+    /* We just test that custom_serializer_func() gets called, not it's performance */
+    char *serialized = NULL;
+    JSON_Value *val = json_value_init_number(0.6);
+    json_set_float_serialization_function(custom_serializer_func);
+    serialized = json_serialize_to_string(val);
+    TEST(STREQ(serialized, "0.6"));
+    TEST(custom_serializer_func_called);
+    json_set_float_serialization_function(NULL);
     json_free_serialized_string(serialized);
     json_value_free(val);
 }


### PR DESCRIPTION
Well, the bottleneck for the our use-case is `sprintf()` for numbers. There are too many numbers to convert on an embedded system.

One minor improvement that I am still hesitant to push, is to return a pessimistic buf-size when json_serialization_size() gets called i.e. to return `PARSON_NUM_BUF_SIZE` instead of calling spritnf() (which would be a good performance booster). This changes some semantics (also in tests), where more memory would get allocated (thantneeded), but that wouldn't be too bad considering that sprintf() is too slow (which opens up a discussion about which is worse: speed or memory over-use).

sprintf() performance is presented here: https://aras-p.info/blog/2022/02/25/Curious-lack-of-sprintf-scaling/

So in this (patch) series, the idea (I am presenting) is that a user can/could provide their own serializer function for double/numbers (in case they don't like sprintf()). But I also included some minor perf stuff that I found along the way. The improvement (the other stuff adds) isl small, but (generally) they're still worth considering.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>