### PR TITLE
Add compatibility for scientific notation

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -376,10 +376,12 @@ static int is_valid_utf8(const char *string, size_t string_len) {
 }
 
 static parson_bool_t is_decimal(const char *string, size_t length) {
-    if (length > 1 && string[0] == '0' && string[1] != '.') {
+    if (length > 1 && string[0] == '0' && 
+	(string[1] != '.' && string[1] != 'e' && string[1] != 'E') {
         return PARSON_FALSE;
     }
-    if (length > 2 && !strncmp(string, "-0", 2) && string[2] != '.') {
+    if (length > 2 && !strncmp(string, "-0", 2) && 
+	(string[2] != '.' && string[2] != 'e' && string[2] != 'E') {
         return PARSON_FALSE;
     }
     while (length--) {


### PR DESCRIPTION
Currently, is_decimal() only checks for a dot as a numeric annotation. Other libraries such as boost::json use scientific annotation instead (e.g. 0e5, 0E5). This patch is supposed to add support for the scientific annotation.