### PR TITLE
fix Arithmetic overflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(parson C)
 
 include (GNUInstallDirs)
 
-set(PARSON_VERSION 1.5.1)
+set(PARSON_VERSION 1.5.2)
 add_library(parson parson.c)
 target_include_directories(parson PUBLIC $<INSTALL_INTERFACE:include>)
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('parson', 'c',
-    version : '1.5.1',
+    version : '1.5.2',
     license : 'MIT',
     meson_version : '>=0.46.0',
     default_options : [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parson",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "repo": "kgabis/parson",
   "description": "Small json parser and reader",
   "keywords": [ "json", "parser" ],

--- a/parson.c
+++ b/parson.c
@@ -1,7 +1,7 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson 1.5.1 (https://github.com/kgabis/parson)
+ Parson 1.5.2 (https://github.com/kgabis/parson)
  Copyright (c) 2012 - 2023 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -32,7 +32,7 @@
 
 #define PARSON_IMPL_VERSION_MAJOR 1
 #define PARSON_IMPL_VERSION_MINOR 5
-#define PARSON_IMPL_VERSION_PATCH 1
+#define PARSON_IMPL_VERSION_PATCH 2
 
 #if (PARSON_VERSION_MAJOR != PARSON_IMPL_VERSION_MAJOR)\
 || (PARSON_VERSION_MINOR != PARSON_IMPL_VERSION_MINOR)\
@@ -441,7 +441,7 @@ static JSON_Status json_object_init(JSON_Object *object, size_t capacity) {
 
     object->count = 0;
     object->cell_capacity = capacity;
-    object->item_capacity = (unsigned int)(capacity * 0.7);
+    object->item_capacity = (unsigned int)(capacity * 7/10);
 
     if (capacity == 0) {
         return JSONSuccess;

--- a/parson.c
+++ b/parson.c
@@ -441,7 +441,7 @@ static JSON_Status json_object_init(JSON_Object *object, size_t capacity) {
 
     object->count = 0;
     object->cell_capacity = capacity;
-    object->item_capacity = (unsigned int)(capacity * 0.7f);
+    object->item_capacity = (unsigned int)(capacity * 0.7);
 
     if (capacity == 0) {
         return JSONSuccess;

--- a/parson.h
+++ b/parson.h
@@ -1,7 +1,7 @@
 /*
  SPDX-License-Identifier: MIT
 
- Parson 1.5.1 (https://github.com/kgabis/parson)
+ Parson 1.5.2 (https://github.com/kgabis/parson)
  Copyright (c) 2012 - 2023 Krzysztof Gabis
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -36,9 +36,9 @@ extern "C"
 
 #define PARSON_VERSION_MAJOR 1
 #define PARSON_VERSION_MINOR 5
-#define PARSON_VERSION_PATCH 1
+#define PARSON_VERSION_PATCH 2
 
-#define PARSON_VERSION_STRING "1.5.1"
+#define PARSON_VERSION_STRING "1.5.2"
 
 #include <stddef.h>   /* size_t */
 


### PR DESCRIPTION
We're getting the following warning:
`Arithmetic overflow: Using operator '*' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '*' to avoid overflow (io.2).`

This PR resolves the warning by making 0.7 a double instead of a float.