### PR TITLE
Simplify meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project('parson', 'c',
     license : 'MIT',
     meson_version : '>=0.46.0',
     default_options : [
-        'c_std=c89', 'optimization=2', 
+        'c_std=c89', 'optimization=2',
         'warning_level=2'
         ]
 )
@@ -12,37 +12,23 @@ parson_sources = ['parson.c']
 
 parson_inc = include_directories('.')
 
-lib_so_version = '0'
-
-parson_shared_lib = shared_library(
-    meson.project_name(),
-    sources: parson_sources,
-    soversion: lib_so_version,
-    install: true
-)
-
-parson_static_lib = static_library(
+parson_lib = library(
     meson.project_name(),
     sources: parson_sources,
     install: true
 )
 
-install_headers('parson.h', subdir : 'parson')
+install_headers('parson.h')
 
-parson_shared_dep = declare_dependency(
+parson = declare_dependency(
     include_directories : parson_inc,
-    link_with : parson_shared_lib
-)
-
-parson_static_dep = declare_dependency(
-    include_directories : parson_inc,
-    link_with : parson_static_lib
+    link_with : parson_lib
 )
 
 pkgconfig = import('pkgconfig')
 
-# will create a pkg config for the shared lib only
-pkgconfig.generate(parson_shared_lib,
+# will create a pkg config
+pkgconfig.generate(parson_lib,
     version: meson.project_version(),
     filebase: meson.project_name(),
     name: meson.project_name(),


### PR DESCRIPTION
This pull request makes the meson.build more compact. If a user would like a static library they will pass -Ddefault_library=static to build one instead of making both a static and shared lib.